### PR TITLE
Queue Producer creates table if it doesn't exist

### DIFF
--- a/src/main/java/org/cdc/gov/sdp/queue/DatabaseQueueComponent.java
+++ b/src/main/java/org/cdc/gov/sdp/queue/DatabaseQueueComponent.java
@@ -46,10 +46,16 @@ public class DatabaseQueueComponent extends UriEndpointComponent {
 	}
 
 	public void createIfNotExists(DataSource ds, String tableName) throws Exception {
-		Connection conn = ds.getConnection();
-		PreparedStatement ps = conn.prepareStatement(getCreateCommand(tableName));
-		ps.executeUpdate();
-		conn.close();
+		Connection conn = null;
+		PreparedStatement ps = null;
+		try {
+			conn = ds.getConnection();
+			ps = conn.prepareStatement(getCreateCommand(tableName));
+			ps.executeUpdate();
+		} finally {
+			ps.close();
+			conn.close();
+		}
 	}
 
 	@Override

--- a/src/main/java/org/cdc/gov/sdp/queue/DatabaseQueueComponent.java
+++ b/src/main/java/org/cdc/gov/sdp/queue/DatabaseQueueComponent.java
@@ -34,10 +34,8 @@ public class DatabaseQueueComponent extends UriEndpointComponent {
 	}
 
 	@Override
-	protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
+	protected Endpoint createEndpoint(String uri, String tableName, Map<String, Object> parameters) throws Exception {
 		DataSource ds = resolveAndRemoveReferenceParameter(parameters, "dataSource", DataSource.class);
-
-		String tableName = getAndRemoveParameter(parameters, "tableName", String.class);
 		if (ds == null) {
 			throw new IllegalArgumentException("DataSource must be configured");
 		}

--- a/src/main/java/org/cdc/gov/sdp/queue/DatabaseQueueComponent.java
+++ b/src/main/java/org/cdc/gov/sdp/queue/DatabaseQueueComponent.java
@@ -1,5 +1,7 @@
 package org.cdc.gov.sdp.queue;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -33,12 +35,31 @@ public class DatabaseQueueComponent extends UriEndpointComponent {
 		super(context, endpointClass);
 	}
 
+	public String getCreateCommand(String tableName) {
+		return ("CREATE TABLE IF NOT EXISTS " + tableName + " (id bigserial primary key,"
+				+ "cbr_id varchar(255) NOT NULL, source varchar(255) NOT NULL, source_id varchar(255) NOT NULL,"
+				+ "source_attributes text default NULL, batch boolean default false, batch_index int default 0,"
+				+ "payload text NOT NULL, cbr_recevied_time varchar (255) NOT NULL, cbr_delivered_time varchar (255) default NULL,"
+				+ "sender varchar (255) default NULL, recipient varchar (255) default NULL, errorCode varchar (255) default NULL,"
+				+ "errorMessage varchar (255) default NULL, attempts int  default 0, status varchar (255) default 'queued',"
+				+ "created_at varchar (255) default NULL, updated_at varchar (255) default NULL)");
+	}
+
+	public void createIfNotExists(DataSource ds, String tableName) throws Exception {
+		Connection conn = ds.getConnection();
+		PreparedStatement ps = conn.prepareStatement(getCreateCommand(tableName));
+		ps.executeUpdate();
+		conn.close();
+	}
+
 	@Override
 	protected Endpoint createEndpoint(String uri, String tableName, Map<String, Object> parameters) throws Exception {
 		DataSource ds = resolveAndRemoveReferenceParameter(parameters, "dataSource", DataSource.class);
 		if (ds == null) {
 			throw new IllegalArgumentException("DataSource must be configured");
 		}
+		this.createIfNotExists(ds, tableName);
+
 		DatabaseQueueEndpoint endpoint = new DatabaseQueueEndpoint(uri, this, ds, tableName);
 
 		return endpoint;

--- a/src/main/java/org/cdc/gov/sdp/queue/DatabaseQueueComponent.java
+++ b/src/main/java/org/cdc/gov/sdp/queue/DatabaseQueueComponent.java
@@ -53,8 +53,12 @@ public class DatabaseQueueComponent extends UriEndpointComponent {
 			ps = conn.prepareStatement(getCreateCommand(tableName));
 			ps.executeUpdate();
 		} finally {
-			ps.close();
-			conn.close();
+			if (ps != null) {
+				ps.close();
+			}
+			if (conn != null) {
+				conn.close();
+			}
 		}
 	}
 

--- a/src/main/java/org/cdc/gov/sdp/queue/DatabaseQueueProducer.java
+++ b/src/main/java/org/cdc/gov/sdp/queue/DatabaseQueueProducer.java
@@ -30,8 +30,6 @@ public class DatabaseQueueProducer extends DefaultProducer {
 
 	private String queueInsertCommand;
 	private DataSource queueDataSource;
-	private Connection queueConnection;
-	private PreparedStatement ps;
 
 	public DatabaseQueueProducer(Endpoint endpoint, String uri, DataSource ds, String tableName) {
 		super(endpoint);
@@ -52,13 +50,8 @@ public class DatabaseQueueProducer extends DefaultProducer {
 		Connection queueConnection = null;
 		PreparedStatement ps = null;
 		try {
-			if (queueConnection == null) {
-				queueConnection = queueDataSource.getConnection();
-			}
-
-			if (ps == null) {
-				ps = queueConnection.prepareStatement(this.queueInsertCommand);
-			}
+			queueConnection = queueDataSource.getConnection();
+			ps = queueConnection.prepareStatement(this.queueInsertCommand);
 
 			Map<String, Object> source_headers = exchange.getIn().getHeaders();
 

--- a/src/main/java/org/cdc/gov/sdp/queue/DatabaseQueueProducer.java
+++ b/src/main/java/org/cdc/gov/sdp/queue/DatabaseQueueProducer.java
@@ -29,22 +29,12 @@ public class DatabaseQueueProducer extends DefaultProducer {
 	private static Logger logger = LogManager.getLogger("SDPQueueLogger");
 
 	private String queueInsertCommand;
-	private String queueTableCreateCommand;
 	private DataSource queueDataSource;
 	private Connection queueConnection;
 	private PreparedStatement ps;
-	private boolean tableCreated = false;
 
 	public DatabaseQueueProducer(Endpoint endpoint, String uri, DataSource ds, String tableName) {
 		super(endpoint);
-
-		queueTableCreateCommand = "CREATE TABLE IF NOT EXISTS " + tableName + " (id bigserial primary key,"
-				+ "cbr_id varchar(255) NOT NULL, source varchar(255) NOT NULL, source_id varchar(255) NOT NULL,"
-				+ "source_attributes text default NULL, batch boolean default false, batch_index int default 0,"
-				+ "payload text NOT NULL, cbr_recevied_time varchar (255) NOT NULL, cbr_delivered_time varchar (255) default NULL,"
-				+ "sender varchar (255) default NULL, recipient varchar (255) default NULL, errorCode varchar (255) default NULL,"
-				+ "errorMessage varchar (255) default NULL, attempts int  default 0, status varchar (255) default 'queued',"
-				+ "created_at varchar (255) default NULL, updated_at varchar (255) default NULL)";
 
 		queueInsertCommand = "INSERT INTO " + tableName
 				+ " (cbr_id, source, source_id, source_attributes , batch, batch_index, payload, cbr_recevied_time, sender, recipient,  attempts, status, created_at, updated_at) "
@@ -64,14 +54,6 @@ public class DatabaseQueueProducer extends DefaultProducer {
 		try {
 			if (queueConnection == null) {
 				queueConnection = queueDataSource.getConnection();
-			}
-
-			if (!tableCreated) {
-				PreparedStatement makeDbIfNeeded = queueConnection.prepareStatement(this.queueTableCreateCommand);
-				String thing = makeDbIfNeeded.toString();
-				System.out.println(thing);
-				makeDbIfNeeded.executeUpdate();
-				tableCreated = true;
 			}
 
 			if (ps == null) {

--- a/src/test/java/org/cdc/gov/sdp/queue/DatabaseQueueCreationConsumerTest.java
+++ b/src/test/java/org/cdc/gov/sdp/queue/DatabaseQueueCreationConsumerTest.java
@@ -1,0 +1,93 @@
+package org.cdc.gov.sdp.queue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.junit.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class DatabaseQueueCreationConsumerTest extends CamelTestSupport {
+
+	private static final String route_id = "test_consume";
+	private static final String driver = "org.postgresql.Driver";
+	private static final String username = "sdp_dbq";
+	private static final String password = "bob";
+	private static final String dsurl = "jdbc:postgresql://localhost:5432/cbr_db";
+
+	private static final String tableName = "temp_fake_table";
+	private static final String drop_temp_table = "drop table if exists " + tableName;
+	private static final String does_table_exist = "select * from pg_tables where tablename='" + tableName + "'";
+
+	@EndpointInject(uri = "mock:mock_endpoint")
+	protected MockEndpoint mock_endpoint;
+
+	@Produce(uri = "direct:start")
+	protected ProducerTemplate template;
+
+	@Override
+	protected JndiRegistry createRegistry() throws Exception {
+		JndiRegistry jndi = super.createRegistry();
+		BasicDataSource ds = new BasicDataSource();
+		ds.setDriverClassName(driver);
+		ds.setUsername(username);
+		ds.setPassword(password);
+		ds.setUrl(dsurl);
+		jndi.bind("dataSource", ds);
+		return jndi;
+	}
+
+	@Override
+	protected void doPreSetup() throws Exception {
+		BasicDataSource ds = new BasicDataSource();
+		ds.setDriverClassName(driver);
+		ds.setUsername(username);
+		ds.setPassword(password);
+		ds.setUrl(dsurl);
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(ds);
+		List<Map<String, Object>> lst;
+
+		jdbcTemplate.update(drop_temp_table);
+		lst = jdbcTemplate.queryForList(does_table_exist);
+		// Ensure table has been dropped prior to routes being built in setup
+		assertEquals(0, lst.size());
+	}
+
+	@Override
+	protected RouteBuilder createRouteBuilder() {
+		// Run during setup before the test, builds the route
+		return new RouteBuilder() {
+			@Override
+			public void configure() {
+				from("sdpqueue:temp_fake_table?dataSource=#dataSource").id(route_id).to("mock:result");
+			}
+		};
+	}
+
+	@Test
+	public void testCreateConsume() throws Exception {
+		String rid = context().getRoutes().get(0).getId();
+		assertEquals(rid, route_id);
+		// Ensure that the route was built
+
+		BasicDataSource ds = new BasicDataSource();
+		ds.setDriverClassName(driver);
+		ds.setUsername(username);
+		ds.setPassword(password);
+		ds.setUrl(dsurl);
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(ds);
+
+		List<Map<String, Object>> lst;
+		lst = jdbcTemplate.queryForList(does_table_exist);
+		assertEquals(1, lst.size());
+		// Ensure that the table exists now
+		// Literally nothing else needs to be done
+	}
+}

--- a/src/test/java/org/cdc/gov/sdp/queue/DatabaseQueueCreationProducerTest.java
+++ b/src/test/java/org/cdc/gov/sdp/queue/DatabaseQueueCreationProducerTest.java
@@ -1,0 +1,93 @@
+package org.cdc.gov.sdp.queue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.junit.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class DatabaseQueueCreationProducerTest extends CamelTestSupport {
+
+	private static final String route_id = "test_produce";
+	private static final String driver = "org.postgresql.Driver";
+	private static final String username = "sdp_dbq";
+	private static final String password = "bob";
+	private static final String dsurl = "jdbc:postgresql://localhost:5432/cbr_db";
+
+	private static final String tableName = "temp_fake_table";
+	private static final String drop_temp_table = "drop table if exists " + tableName;
+	private static final String does_table_exist = "select * from pg_tables where tablename='" + tableName + "'";
+
+	@EndpointInject(uri = "mock:mock_endpoint")
+	protected MockEndpoint mock_endpoint;
+
+	@Produce(uri = "direct:start")
+	protected ProducerTemplate template;
+
+	@Override
+	protected JndiRegistry createRegistry() throws Exception {
+		JndiRegistry jndi = super.createRegistry();
+		BasicDataSource ds = new BasicDataSource();
+		ds.setDriverClassName(driver);
+		ds.setUsername(username);
+		ds.setPassword(password);
+		ds.setUrl(dsurl);
+		jndi.bind("dataSource", ds);
+		return jndi;
+	}
+
+	@Override
+	protected void doPreSetup() throws Exception {
+		BasicDataSource ds = new BasicDataSource();
+		ds.setDriverClassName(driver);
+		ds.setUsername(username);
+		ds.setPassword(password);
+		ds.setUrl(dsurl);
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(ds);
+		List<Map<String, Object>> lst;
+
+		jdbcTemplate.update(drop_temp_table);
+		lst = jdbcTemplate.queryForList(does_table_exist);
+		// Ensure table has been dropped prior to routes being built in setup
+		assertEquals(0, lst.size());
+	}
+
+	@Override
+	protected RouteBuilder createRouteBuilder() {
+		// Run during setup before the test, builds the route
+		return new RouteBuilder() {
+			@Override
+			public void configure() {
+				from("direct:start").id(route_id).to("sdpqueue:temp_fake_table?dataSource=#dataSource");
+			}
+		};
+	}
+
+	@Test
+	public void testCreateProduce() throws Exception {
+		String rid = context().getRoutes().get(0).getId();
+		assertEquals(rid, route_id);
+		// Ensure that the route was built
+
+		BasicDataSource ds = new BasicDataSource();
+		ds.setDriverClassName(driver);
+		ds.setUsername(username);
+		ds.setPassword(password);
+		ds.setUrl(dsurl);
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(ds);
+
+		List<Map<String, Object>> lst;
+		lst = jdbcTemplate.queryForList(does_table_exist);
+		assertEquals(1, lst.size());
+		// Ensure that the table exists now
+		// Literally nothing else needs to be done
+	}
+}

--- a/src/test/resources/DatabaseQueueComponentTest-context.xml
+++ b/src/test/resources/DatabaseQueueComponentTest-context.xml
@@ -35,11 +35,11 @@
     </route>
     <route id="producer_test_route">
       <from id="producer_from" uri="direct:producer_test"/>
-      <to id="producer_to" uri="sdpqueue:push?dataSource=sdpqDataSource&amp;tableName=message_queue"/>
+      <to id="producer_to" uri="sdpqueue:message_queue?dataSource=sdpqDataSource"/>
       <to id="producer_mock_to" uri="mock:mock_endpoint"/>
     </route>
     <route id="consumer_test_route">
-      <from id="consumer_from" uri="sdpqueue:pull?dataSource=sdpqDataSource&amp;tableName=message_queue"/>
+      <from id="consumer_from" uri="sdpqueue:message_queue?dataSource=sdpqDataSource"/>
       <to id="consumer_mock_to" uri="mock:mock_endpoint"/>
     </route>
   </camelContext>

--- a/src/test/resources/DatabaseQueueComponentTest-context.xml
+++ b/src/test/resources/DatabaseQueueComponentTest-context.xml
@@ -22,10 +22,7 @@
     <property name="location" value="classpath:application.properties"/>
   </bean>
   <bean class="org.cdc.gov.sdp.PhinMSTransformer" id="myProcessor"/>
-  <bean class="org.cdc.gov.sdp.aphl.AIMSHeaderProcessor" id="aimsHeaderProcessor"/>
-  <bean class="org.cdc.gov.sdp.JSONTransformer" id="jsonTransformer"/>
   <bean class="org.cdc.gov.sdp.ArrayListAggregationStrategy" id="agg"/>
-  <bean class="org.cdc.gov.sdp.HTTP4Transformer" id="httpTransformer"/>
   <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
     <route id="_route1">
       <from id="_from1" uri="direct:start"/>
@@ -33,17 +30,17 @@
       <split id="batchSplitter" parallelProcessing="false" strategyRef="agg">
         <method beanType="org.cdc.gov.sdp.HL7V2BatchSplitter"
           method="split" trim="false"/>
-        <to id="_to1" uri="direct:test2"/>
+        <to id="_to1" uri="direct:producer_test"/>
       </split>
     </route>
-    <route id="_route2">
-      <from id="_from2" uri="direct:test2"/>
-      <to id="queue_component_test1" uri="sdpqueue:push?dataSource=nndssDataSource&amp;tableName=message_queue"/>
-      <to id="_to2" uri="mock:foo"/>
+    <route id="producer_test_route">
+      <from id="producer_from" uri="direct:producer_test"/>
+      <to id="producer_to" uri="sdpqueue:push?dataSource=sdpqDataSource&amp;tableName=message_queue"/>
+      <to id="producer_mock_to" uri="mock:mock_endpoint"/>
     </route>
-    <route id="_route3">
-      <from id="_from3" uri="sdpqueue:junkdata?dataSource=sdpqDataSource&amp;tableName=message_queue"/>
-      <to id="_to3" uri="mock:foo"/>
+    <route id="consumer_test_route">
+      <from id="consumer_from" uri="sdpqueue:pull?dataSource=sdpqDataSource&amp;tableName=message_queue"/>
+      <to id="consumer_mock_to" uri="mock:mock_endpoint"/>
     </route>
   </camelContext>
 </beans>


### PR DESCRIPTION
When attempting to write to a table (now given in the base URI and not by a named parameter) the queue producer now attempts to create the table if it does not already exist.