### PR TITLE
Log sanitization

### DIFF
--- a/src/main/java/gov/cdc/sdp/cbr/aphl/AphlS3Producer.java
+++ b/src/main/java/gov/cdc/sdp/cbr/aphl/AphlS3Producer.java
@@ -141,7 +141,6 @@ public class AphlS3Producer extends DefaultProducer {
 						.withUploadId(initResponse.getUploadId()).withPartNumber(part).withFileOffset(filePosition)
 						.withFile(filePayload).withPartSize(partSize);
 
-				// LOG.trace("Uploading part [{}] for {}", part, keyName);
 				partETags.add(getEndpoint().getS3Client().uploadPart(uploadRequest).getPartETag());
 
 				filePosition += partSize;
@@ -209,15 +208,10 @@ public class AphlS3Producer extends DefaultProducer {
 			// PutObjectRequest#setAccessControlList for more details
 			putObjectRequest.setAccessControlList(acl);
 		}
-		// LOG.trace("Put object [{}] from exchange [{}]...", putObjectRequest,
-		// exchange);
 
 		PutObjectResult putObjectResult = getEndpoint().getS3Client().putObject(putObjectRequest);
 
-		// LOG.info("Received result [{}]", putObjectResult.getETag());
-
 		Message message = getMessageForResponse(exchange);
-		// LOG.info(message.getBody(String.class));
 		message.setHeader(S3Constants.E_TAG, putObjectResult.getETag());
 		if (putObjectResult.getVersionId() != null) {
 			message.setHeader(S3Constants.VERSION_ID, putObjectResult.getVersionId());

--- a/src/main/java/gov/cdc/sdp/cbr/aphl/AphlS3Producer.java
+++ b/src/main/java/gov/cdc/sdp/cbr/aphl/AphlS3Producer.java
@@ -121,7 +121,7 @@ public class AphlS3Producer extends DefaultProducer {
 			initRequest.setAccessControlList(acl);
 		}
 
-		LOG.trace("Initiating multipart upload [{}] from exchange [{}]...", initRequest, exchange);
+		LOG.trace("Initiating multipart upload ...");
 
 		final InitiateMultipartUploadResult initResponse = getEndpoint().getS3Client()
 				.initiateMultipartUpload(initRequest);
@@ -141,7 +141,7 @@ public class AphlS3Producer extends DefaultProducer {
 						.withUploadId(initResponse.getUploadId()).withPartNumber(part).withFileOffset(filePosition)
 						.withFile(filePayload).withPartSize(partSize);
 
-				LOG.trace("Uploading part [{}] for {}", part, keyName);
+				// LOG.trace("Uploading part [{}] for {}", part, keyName);
 				partETags.add(getEndpoint().getS3Client().uploadPart(uploadRequest).getPartETag());
 
 				filePosition += partSize;
@@ -209,11 +209,12 @@ public class AphlS3Producer extends DefaultProducer {
 			// PutObjectRequest#setAccessControlList for more details
 			putObjectRequest.setAccessControlList(acl);
 		}
-		LOG.trace("Put object [{}] from exchange [{}]...", putObjectRequest, exchange);
+		// LOG.trace("Put object [{}] from exchange [{}]...", putObjectRequest,
+		// exchange);
 
 		PutObjectResult putObjectResult = getEndpoint().getS3Client().putObject(putObjectRequest);
 
-		LOG.info("Received result [{}]", putObjectResult.getETag());
+		// LOG.info("Received result [{}]", putObjectResult.getETag());
 
 		Message message = getMessageForResponse(exchange);
 		// LOG.info(message.getBody(String.class));


### PR DESCRIPTION
Edited a lone file to doubly ensure that nothing but IDs ever make it to log messages.

There are many other log instances throughout our components, but only these messages -- trace messages in fact -- ever came close to putting anything in the log other than message IDs or CBR_IDs or similar.

Someone else may want to independently confirm that fact, rather than review my commenting out a few lines in a single file.