### PR TITLE
Removing items that override external config

### DIFF
--- a/foodNet/src/main/resources/spring/camel-context.xml
+++ b/foodNet/src/main/resources/spring/camel-context.xml
@@ -12,14 +12,9 @@
         <property name="username" value="${sdpqDataSource.jdbc.username}"/>
         <property name="password" value="${sdpqDataSource.jdbc.password}"/>
     </bean>
-    <bean
-        class="org.apache.camel.spring.spi.BridgePropertyPlaceholderConfigurer" id="bridgePropertyPlaceholder">
-        <property name="location" value="classpath:application.properties"/>
-    </bean>
     <bean class="gov.cdc.sdp.cbr.aphl.AIMSHeaderProcessor" id="aimsHeaderProcessor"/>
     <!-- Define a traditional camel context here -->
     <camelContext id="camel" trace="false" xmlns="http://camel.apache.org/schema/spring">
-        <propertyPlaceholder id="properties" location="application.properties"/>
         <!-- and the redelivery policy is a profile where we can configure it -->
         <redeliveryPolicyProfile id="myPolicy" maximumRedeliveries="1"
             redeliveryDelay="2000" retryAttemptedLogLevel="WARN"/>


### PR DESCRIPTION
These items cause Spring Boot to ignore external application.properties files.

I know that this is a bit out of our ordinary processes, but the goal here is to get this fix into Version 1.1. This change is needed so that the foodNet Camel Context can load external application.properties files when they are mounted as a Config Map when deployed in OpenShift.

When this PR is accepted, we will need to update the Version 1.1 tag.