### PR TITLE
Use JBoss AMQ

### DIFF
--- a/configuration/settings.xml
+++ b/configuration/settings.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2005-2016 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <profiles>
+    <profile>
+      <id>fuse.repos</id>
+
+      <repositories>
+        
+        <repository>
+          <id>maven.central</id>
+          <name>Maven Central</name>
+          <url>https://repo1.maven.org/maven2</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+ 
+        
+        <repository>
+          <id>redhat.ga</id>
+          <name>Red Hat General Availability Repository</name>
+          <url>https://maven.repository.redhat.com/ga</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+ 
+        
+        <repository>
+          <id>redhat.ea</id>
+          <name>Red Hat Early Access Repository</name>
+          <url>https://maven.repository.redhat.com/earlyaccess/all</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+ 
+        
+        
+        
+      </repositories>
+
+      <pluginRepositories>
+        
+        <pluginRepository>
+          <id>maven.central</id>
+          <name>Maven Central</name>
+          <url>https://repo1.maven.org/maven2</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+ 
+        
+        <pluginRepository>
+          <id>redhat.ga</id>
+          <name>Red Hat General Availability Repository</name>
+          <url>https://maven.repository.redhat.com/ga</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+ 
+        
+        <pluginRepository>
+          <id>redhat.ea</id>
+          <name>Red Hat Early Access Repository</name>
+          <url>https://maven.repository.redhat.com/earlyaccess/all</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+ 
+        
+        
+        
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>fuse.repos</activeProfile>
+  </activeProfiles>
+
+</settings>

--- a/foodNet/src/main/resources/application.properties
+++ b/foodNet/src/main/resources/application.properties
@@ -10,45 +10,15 @@ server.address=0.0.0.0
 management.address=0.0.0.0
 
 # lets use a different management port in case you need to listen to HTTP requests on 8080
-management.port=8081
+management.port=8091
+server.port = 8090
 
 # disable all management endpoints except health
 endpoints.enabled = false
 endpoints.health.enabled = true
 
-phinms.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-phinms.jdbc.url=jdbc:sqlserver://<server name>:1433;databaseName=<DB>
-phinms.jdbc.username=
-phinms.jdbc.password=
-
-
-sdpqDataSource.jdbc.driverClassName=org.postgresql.Driver
-sdpqDataSource.jdbc.url=jdbc:postgresql://<server>:5432/<db>
-sdpqDataSource.jdbc.username=
-sdpqDataSource.jdbc.password=
-
-
-
-phinms.table=dbo.message_inq
-phinms.service=MVPS
-phinms.sql=select * from ${phinms.table} where processingStatus = 'queued' and  (applicationStatus is NULL or applicationStatus='NULL')?dataSource=phinMsDataSource&onConsume=update ${phinms.table} set applicationStatus='completed' where recordId=:#recordId&onConsumeFailed=update ${phinms.table} set applicationStatus='failed' where recordId=:#recordId&delay=10000
-
-foodNet.queue=foodNetQueue?tableName=foodNetQueue&dataSource=sdpqDataSource
-nndss.queue=nndssQueue?tableName=nndssQueue&dataSource=sdpqDataSource
-
-
-
-aims.bucketName=
-aims.AccessKey=
-aims.SecretAccessKey=
-aims.S3Url=
-aims.url=?amazonS3Endpoint=&accessKey=&secretKey=
+aims.AccessKey=accessKey1
+aims.SecretAccessKey=verySecretKey1
+aims.url=dabucket?amazonS3Endpoint=http://localhost:8000&accessKey=accessKey1&secretKey=verySecretKey1
 aims.SQSUrl=
 aims.SQSNotificationURL=
-
-email.uri=smtp://mail.mitre.org?
-email.debugMode=debugMode=true
-email.to=ecole@mitre.org
-email.from=cdcsdp@mitre.org
-email.subject=SDP-CBR Error
-email.default_body=An error has occurred.\n\n 

--- a/foodNet/src/main/resources/application.properties
+++ b/foodNet/src/main/resources/application.properties
@@ -19,6 +19,8 @@ endpoints.health.enabled = true
 
 aims.AccessKey=accessKey1
 aims.SecretAccessKey=verySecretKey1
-aims.url=dabucket?amazonS3Endpoint=http://localhost:8000&accessKey=accessKey1&secretKey=verySecretKey1
+aims.url=dabucket?amazonS3Endpoint=http://localhost:8000&accessKey=wrong&secretKey=verySecretKey1
 aims.SQSUrl=
 aims.SQSNotificationURL=
+
+queue.url=tcp://localhost:61616

--- a/foodNet/src/main/resources/application.properties
+++ b/foodNet/src/main/resources/application.properties
@@ -24,3 +24,5 @@ aims.SQSUrl=
 aims.SQSNotificationURL=
 
 queue.url=tcp://localhost:61616
+queue.userName=test
+queue.password=test

--- a/foodNet/src/main/resources/spring/camel-context.xml
+++ b/foodNet/src/main/resources/spring/camel-context.xml
@@ -4,17 +4,12 @@
     xmlns:context="http://www.springframework.org/schema/context"
     xmlns:jee="http://www.springframework.org/schema/jee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd                                http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd                        ">
-    <!-- START SNIPPET: e1 -->
-    <bean class="org.apache.commons.dbcp.BasicDataSource"
-        destroy-method="close" id="sdpqDataSource" primary="true">
-        <property name="driverClassName" value="${sdpqDataSource.jdbc.driverClassName}"/>
-        <property name="url" value="${sdpqDataSource.jdbc.url}"/>
-        <property name="username" value="${sdpqDataSource.jdbc.username}"/>
-        <property name="password" value="${sdpqDataSource.jdbc.password}"/>
-    </bean>
     <bean
         class="org.apache.camel.spring.spi.BridgePropertyPlaceholderConfigurer" id="bridgePropertyPlaceholder">
         <property name="location" value="classpath:application.properties"/>
+    </bean>
+    <bean id="activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
+      <property name="brokerURL" value="tcp://localhost:61616"/>
     </bean>
     <bean class="gov.cdc.sdp.cbr.aphl.AIMSHeaderProcessor" id="aimsHeaderProcessor"/>
     <!-- Define a traditional camel context here -->
@@ -23,13 +18,19 @@
         <!-- and the redelivery policy is a profile where we can configure it -->
         <redeliveryPolicyProfile id="myPolicy" maximumRedeliveries="1"
             redeliveryDelay="2000" retryAttemptedLogLevel="WARN"/>
+
         <route id="FoodNetRoute">
-            <from id="_from3" uri="sdpqueue:{{foodNet.queue}}"/>
+            <from id="_from3" uri="activemq:queue:foodNet"/>
             <setHeader headerName="CamelAwsS3Key" id="setAwsS3Key">
                 <simple>${in.header.CBR_ID}</simple>
             </setHeader>
             <camel:process id="foodNetAimsHeaderProcess" ref="aimsHeaderProcessor"/>
             <to id="_to_s3" uri="aphl-s3://{{aims.url}}"/>
+            <camel:onException>
+              <camel:exception>java.lang.Exception</camel:exception>
+              <camel:setHeader headerName="Error"> <simple>Could not be delivered to S3</simple></camel:setHeader>
+              <to uri="activemq:queue:deadLetter"/>
+            </camel:onException>
         </route>
     </camelContext>
 </beans>

--- a/foodNet/src/main/resources/spring/camel-context.xml
+++ b/foodNet/src/main/resources/spring/camel-context.xml
@@ -8,8 +8,14 @@
         class="org.apache.camel.spring.spi.BridgePropertyPlaceholderConfigurer" id="bridgePropertyPlaceholder">
         <property name="location" value="classpath:application.properties"/>
     </bean>
-    <bean id="activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
-      <property name="brokerURL" value="tcp://localhost:61616"/>
+    <bean id="activemq" class="org.apache.camel.component.jms.JmsComponent">
+        <property name="connectionFactory">
+            <bean class="org.apache.activemq.ActiveMQConnectionFactory">
+                <property name="brokerURL" value="${queue.url}"/>
+                <property name="userName" value="${queue.userName}"/>
+                <property name="password" value="${queue.password}"/>
+            </bean>
+        </property>
     </bean>
     <bean class="gov.cdc.sdp.cbr.aphl.AIMSHeaderProcessor" id="aimsHeaderProcessor"/>
     <!-- Define a traditional camel context here -->

--- a/foodNet/src/main/resources/spring/camel-context.xml
+++ b/foodNet/src/main/resources/spring/camel-context.xml
@@ -16,7 +16,6 @@
     <bean class="gov.cdc.sdp.cbr.aphl.AIMSHeaderProcessor" id="aimsHeaderProcessor"/>
     <!-- Define a traditional camel context here -->
     <camelContext id="camel" trace="false" xmlns="http://camel.apache.org/schema/spring">
-        <propertyPlaceholder id="properties" location="application.properties"/>
         <!-- and the redelivery policy is a profile where we can configure it -->
         <redeliveryPolicyProfile id="myPolicy" maximumRedeliveries="1"
             redeliveryDelay="2000" retryAttemptedLogLevel="WARN"/>

--- a/foodNet/src/main/resources/spring/camel-context.xml
+++ b/foodNet/src/main/resources/spring/camel-context.xml
@@ -3,11 +3,7 @@
     xmlns:camel="http://camel.apache.org/schema/spring"
     xmlns:context="http://www.springframework.org/schema/context"
     xmlns:jee="http://www.springframework.org/schema/jee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd                                http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd                        ">
-    <bean
-        class="org.apache.camel.spring.spi.BridgePropertyPlaceholderConfigurer" id="bridgePropertyPlaceholder">
-        <property name="location" value="classpath:application.properties"/>
-    </bean>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd                                http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
     <bean id="activemq" class="org.apache.camel.component.jms.JmsComponent">
         <property name="connectionFactory">
             <bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/phinms/src/main/resources/application.properties
+++ b/phinms/src/main/resources/application.properties
@@ -25,3 +25,4 @@ phinms.table=message_inq
 phinms.sql=select * from ${phinms.table} where processingStatus = 'queued' and  (applicationStatus is NULL or applicationStatus='NULL')?dataSource=phinMsDataSource&onConsume=update ${phinms.table} set applicationStatus='completed' where recordId=:#recordId&onConsumeFailed=update ${phinms.table} set applicationStatus='failed' where recordId=:#recordId&delay=10000
 
 foodNet.queue=foodNetQueue?dataSource=sdpqDataSource
+queue.url=tcp://localhost:61616

--- a/phinms/src/main/resources/application.properties
+++ b/phinms/src/main/resources/application.properties
@@ -16,39 +16,12 @@ management.port=8081
 endpoints.enabled = false
 endpoints.health.enabled = true
 
-phinms.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-phinms.jdbc.url=jdbc:sqlserver://<server name>:1433;databaseName=<DB>
-phinms.jdbc.username=
-phinms.jdbc.password=
+phinms.jdbc.driverClassName=org.postgresql.Driver
+phinms.jdbc.url=jdbc:postgresql://localhost:5432/sdp_db
+phinms.jdbc.username=sdp_dbq
+phinms.jdbc.password=bob
 
-
-sdpqDataSource.jdbc.driverClassName=org.postgresql.Driver
-sdpqDataSource.jdbc.url=jdbc:postgresql://<server>:5432/<db>
-sdpqDataSource.jdbc.username=
-sdpqDataSource.jdbc.password=
-
-
-
-phinms.table=dbo.message_inq
-phinms.service=MVPS
+phinms.table=message_inq
 phinms.sql=select * from ${phinms.table} where processingStatus = 'queued' and  (applicationStatus is NULL or applicationStatus='NULL')?dataSource=phinMsDataSource&onConsume=update ${phinms.table} set applicationStatus='completed' where recordId=:#recordId&onConsumeFailed=update ${phinms.table} set applicationStatus='failed' where recordId=:#recordId&delay=10000
 
-foodNet.queue=foodNetQueue?tableName=foodNetQueue&dataSource=sdpqDataSource
-nndss.queue=nndssQueue?tableName=nndssQueue&dataSource=sdpqDataSource
-
-
-
-aims.bucketName=
-aims.AccessKey=
-aims.SecretAccessKey=
-aims.S3Url=
-aims.url=?amazonS3Endpoint=&accessKey=&secretKey=
-aims.SQSUrl=
-aims.SQSNotificationURL=
-
-email.uri=smtp://mail.mitre.org?
-email.debugMode=debugMode=true
-email.to=ecole@mitre.org
-email.from=cdcsdp@mitre.org
-email.subject=SDP-CBR Error
-email.default_body=An error has occurred.\n\n 
+foodNet.queue=foodNetQueue?dataSource=sdpqDataSource

--- a/phinms/src/main/resources/spring/camel-context.xml
+++ b/phinms/src/main/resources/spring/camel-context.xml
@@ -11,10 +11,14 @@
         <property name="username" value="${phinms.jdbc.username}"/>
         <property name="password" value="${phinms.jdbc.password}"/>
     </bean>
-    <bean class="org.apache.activemq.camel.component.ActiveMQComponent" id="activemq">
-        <property name="brokerURL" value="${queue.url}"/>
-        <property name="userName" value="${queue.userName}"/>
-        <property name="password" value="${queue.password}"/>
+    <bean id="activemq" class="org.apache.camel.component.jms.JmsComponent">
+        <property name="connectionFactory">
+            <bean class="org.apache.activemq.ActiveMQConnectionFactory">
+                <property name="brokerURL" value="${queue.url}"/>
+                <property name="userName" value="${queue.userName}"/>
+                <property name="password" value="${queue.password}"/>
+            </bean>
+        </property>
     </bean>
     <bean class="gov.cdc.sdp.cbr.PhinMSTransformer" id="myProcessor"/>
     <bean class="gov.cdc.sdp.cbr.JSONTransformer" id="jsonTransformer"/>

--- a/phinms/src/main/resources/spring/camel-context.xml
+++ b/phinms/src/main/resources/spring/camel-context.xml
@@ -13,6 +13,8 @@
     </bean>
     <bean class="org.apache.activemq.camel.component.ActiveMQComponent" id="activemq">
         <property name="brokerURL" value="${queue.url}"/>
+        <property name="userName" value="${queue.userName}"/>
+        <property name="password" value="${queue.password}"/>
     </bean>
     <bean class="gov.cdc.sdp.cbr.PhinMSTransformer" id="myProcessor"/>
     <bean class="gov.cdc.sdp.cbr.JSONTransformer" id="jsonTransformer"/>

--- a/phinms/src/main/resources/spring/camel-context.xml
+++ b/phinms/src/main/resources/spring/camel-context.xml
@@ -3,8 +3,7 @@
     xmlns:camel="http://camel.apache.org/schema/spring"
     xmlns:context="http://www.springframework.org/schema/context"
     xmlns:jee="http://www.springframework.org/schema/jee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd                                http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd                        ">
-    <!-- START SNIPPET: e1 -->
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
     <bean class="org.apache.commons.dbcp.BasicDataSource"
         destroy-method="close" id="phinMsDataSource">
         <property name="driverClassName" value="${phinms.jdbc.driverClassName}"/>
@@ -12,23 +11,14 @@
         <property name="username" value="${phinms.jdbc.username}"/>
         <property name="password" value="${phinms.jdbc.password}"/>
     </bean>
-    <bean class="org.apache.commons.dbcp.BasicDataSource"
-        destroy-method="close" id="sdpqDataSource" primary="true">
-        <property name="driverClassName" value="${sdpqDataSource.jdbc.driverClassName}"/>
-        <property name="url" value="${sdpqDataSource.jdbc.url}"/>
-        <property name="username" value="${sdpqDataSource.jdbc.username}"/>
-        <property name="password" value="${sdpqDataSource.jdbc.password}"/>
+    <bean id="activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
+      <property name="brokerURL" value="tcp://localhost:61616"/>
     </bean>
     <bean class="gov.cdc.sdp.cbr.PhinMSTransformer" id="myProcessor"/>
     <bean class="gov.cdc.sdp.cbr.JSONTransformer" id="jsonTransformer"/>
     <bean class="gov.cdc.sdp.cbr.ArrayListAggregationStrategy" id="agg"/>
     <bean class="gov.cdc.sdp.cbr.HTTP4Transformer" id="httpTransformer"/>
-    <bean class="gov.cdc.sdp.cbr.SDPMessageIdRepository" id="foodNetIDRepo">
-        <constructor-arg ref="sdpqDataSource"/>
-        <constructor-arg value="foodNetIds"/>
-        <constructor-arg value="foodnetMessageIds"/>
-    </bean>
-    <!-- Define a traditional camel context here -->
+
     <camelContext id="camel" trace="false" xmlns="http://camel.apache.org/schema/spring">
         <dataFormats>
             <hl7 id="unvalidatedHl7" validate="false"/>
@@ -36,13 +26,6 @@
         <!-- and the redelivery policy is a profile where we can configure it -->
         <redeliveryPolicyProfile id="myPolicy" maximumRedeliveries="1"
             redeliveryDelay="2000" retryAttemptedLogLevel="WARN"/>
-        <!-- <onException id="_onException1"> <exception>java.lang.Exception</exception> 
-      <handled> <constant>false</constant> </handled> <log id="log_error" message="EXCEPTION 
-      \n ${exception.stacktrace}"/> <setHeader headerName="from"> <simple>{{email.from}}</simple> 
-      </setHeader> <setHeader headerName="to"> <simple>{{email.to}}</simple> </setHeader> 
-      <setHeader headerName="subject"> <simple>{{email.subject}}</simple> </setHeader> 
-      <setBody id="_onException_0"> <simple>${properties:email.default_body}${exception.message}</simple> 
-      </setBody> <to id="_to_email" uri="{{email.uri}}{{email.debugMode}}"/> </onException> -->
         <route id="PHINMS">
             <from id="cbr_phinms" uri="sql:{{phinms.sql}}"/>
             <camel:process id="setHeaders" ref="myProcessor"/>
@@ -54,42 +37,36 @@
                         <camel:method
                             beanType="gov.cdc.sdp.cbr.HL7V2BatchSplitter"
                             method="split" trim="false"/>
-                        <to id="_to1" uri="direct:multicast"/>
+                        <to id="toMainQueue" uri="activemq:queue:phinmsInQ"/>
                     </camel:split>
                     <setHeader headerName="errorMsg" id="_setHeader1">
                         <simple>${in.header.ERROR_COUNT} of ${in.header.MSG_COUNT} messages failed.</simple>
                     </setHeader>
                 </camel:when>
                 <camel:otherwise id="_otherwise1">
-                    <to id="_to2" uri="direct:multicast"/>
+                    <to id="_to2" uri="activemq:queue:deadLetter"/>
                     <setHeader headerName="errorMsg" id="_setHeader2">
                         <simple>An error occurred.</simple>
                     </setHeader>
                 </camel:otherwise>
             </camel:choice>
         </route>
-        <route id="Multicast">
-            <from id="_from1" uri="direct:multicast"/>
-            <multicast id="_multicast2">
-                <to id="_to31" uri="direct:foodNetFilter"/>
-            </multicast>
-        </route>
         <route id="foodNetFilter">
-            <from id="_from2" uri="direct:foodNetFilter"/>
-            <idempotentConsumer id="_idempotentConsumer" messageIdRepositoryRef="foodNetIDRepo">
-                <header>CBR_ID</header>
-                <log id="_log1" message="FOOD NET FILTER"/>
-                <setHeader headerName="HL7Filter" id="_setHeader7">
-                    <constant>*(/.MSH-21(*)-1 EQUALS FDD_MMG_V1.0)</constant>
-                </setHeader>
-                <unmarshal id="_unmarshal1" ref="unvalidatedHl7"/>
-                <filter id="foodNetFilter">
-                    <method beanType="gov.cdc.sdp.cbr.filter.HL7Terser" method="filter"/>
-                    <marshal id="_marshal1" ref="unvalidatedHl7"/>
-                    <log id="fnf_passed_log" message="Exchange passed FoodNet filter"/>
-                    <to id="foodNetQueue" uri="sdpqueue:{{foodNet.queue}}"/>
-                </filter>
-            </idempotentConsumer>
+            <from id="fromInQ" uri="activemq:queue:phinmsInQ"/>
+            <log id="_log1" message="FOOD NET FILTER"/>
+            <setHeader headerName="HL7Filter" id="_setHeader7">
+                <constant>*(/.MSH-21(*)-1 EQUALS FDD_MMG_V1.0)</constant>
+            </setHeader>
+            <choice>
+              <when>
+                <method beanType="gov.cdc.sdp.cbr.filter.HL7Terser" method="filter"/>
+                <log id="fnf_passed_log" message="Exchange passed FoodNet filter"/>
+                <to id="foodNetQueue" uri="activemq:queue:foodNet"/>
+              </when>
+              <otherwise>
+                <to id="dead" uri="activemq:queue:deadLetter"/>
+              </otherwise>
+            </choice>
         </route>
     </camelContext>
 </beans>

--- a/phinms/src/main/resources/spring/camel-context.xml
+++ b/phinms/src/main/resources/spring/camel-context.xml
@@ -11,14 +11,13 @@
         <property name="username" value="${phinms.jdbc.username}"/>
         <property name="password" value="${phinms.jdbc.password}"/>
     </bean>
-    <bean id="activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
-      <property name="brokerURL" value="tcp://localhost:61616"/>
+    <bean class="org.apache.activemq.camel.component.ActiveMQComponent" id="activemq">
+        <property name="brokerURL" value="${queue.url}"/>
     </bean>
     <bean class="gov.cdc.sdp.cbr.PhinMSTransformer" id="myProcessor"/>
     <bean class="gov.cdc.sdp.cbr.JSONTransformer" id="jsonTransformer"/>
     <bean class="gov.cdc.sdp.cbr.ArrayListAggregationStrategy" id="agg"/>
     <bean class="gov.cdc.sdp.cbr.HTTP4Transformer" id="httpTransformer"/>
-
     <camelContext id="camel" trace="false" xmlns="http://camel.apache.org/schema/spring">
         <dataFormats>
             <hl7 id="unvalidatedHl7" validate="false"/>
@@ -57,15 +56,15 @@
             <setHeader headerName="HL7Filter" id="_setHeader7">
                 <constant>*(/.MSH-21(*)-1 EQUALS FDD_MMG_V1.0)</constant>
             </setHeader>
-            <choice>
-              <when>
-                <method beanType="gov.cdc.sdp.cbr.filter.HL7Terser" method="filter"/>
-                <log id="fnf_passed_log" message="Exchange passed FoodNet filter"/>
-                <to id="foodNetQueue" uri="activemq:queue:foodNet"/>
-              </when>
-              <otherwise>
-                <to id="dead" uri="activemq:queue:deadLetter"/>
-              </otherwise>
+            <choice id="_choice2">
+                <when id="_when2">
+                    <method beanType="gov.cdc.sdp.cbr.filter.HL7Terser" method="filter"/>
+                    <log id="fnf_passed_log" message="Exchange passed FoodNet filter"/>
+                    <to id="foodNetQueue" uri="activemq:queue:foodNet"/>
+                </when>
+                <otherwise id="_otherwise2">
+                    <to id="dead" uri="activemq:queue:deadLetter"/>
+                </otherwise>
             </choice>
         </route>
     </camelContext>

--- a/phinms/src/test/ruby/test_phinms_insert.rb
+++ b/phinms/src/test/ruby/test_phinms_insert.rb
@@ -1,0 +1,22 @@
+require 'sequel'
+require 'csv'
+
+input = File.read ARGV[0]
+messages = CSV.parse(input, headers: true)
+
+row_hash = messages[0].to_h
+
+lower_row = {}
+
+row_hash.each_pair do |k, v|
+  lower_row[k.downcase] = v
+end
+
+lower_row.delete('payloadbinarycontent')
+lower_row['action'] ||= 'test'
+lower_row['encryption'] ||= 'none'
+lower_row['localfilename'] ||= 'v2message.txt'
+lower_row['service'] ||= 'service'
+
+DB = Sequel.connect(adapter: 'postgres', host: 'localhost', database: 'sdp_db', user: 'sdp_dbq', password: 'bob')
+DB[:message_inq].insert(lower_row)


### PR DESCRIPTION
Changes to allow for the use of JBoss AMQ, which is really a repackaged version of ActiveMQ. This includes work on the Camel contexts to allow things to be properly configured via external application.properties. It also includes a ruby test script that can be used to insert a row into a postgres based mock of PHIN MS.